### PR TITLE
Errors can't be bubbled up

### DIFF
--- a/src/compiled.rs
+++ b/src/compiled.rs
@@ -147,6 +147,20 @@ mod tests {
     }
 
     #[test]
+    fn compiled_can_pass_up_errors() {
+        fn inner() -> Result<String, Box<dyn std::error::Error>> {
+            let formatter = ParsedFmt::new(
+                "Hello, {recipient}. Hope you are having a nice {time_descriptor}.",
+            )?;
+
+            Ok(formatter.with_args(&Message).to_string())
+        }
+
+        let expected = "Hello, World. Hope you are having a nice morning.";
+        assert_eq!(inner().unwrap(), expected);
+    }
+
+    #[test]
     fn compiled_failed_parsing() {
         let err =
             ParsedFmt::new("Hello, {recipient}. Hope you are having a nice {time_descriptor.")

--- a/src/compiled.rs
+++ b/src/compiled.rs
@@ -161,6 +161,19 @@ mod tests {
     }
 
     #[test]
+    fn compiled_can_pass_up_errors_2() {
+        fn inner(format: &str) -> Result<String, Box<dyn std::error::Error>> {
+            let formatter = ParsedFmt::new(format)?;
+
+            Ok(formatter.with_args(&Message).to_string())
+        }
+
+        let format = "Hello, {recipient}. Hope you are having a nice {time_descriptor}.";
+        let expected = "Hello, World. Hope you are having a nice morning.";
+        assert_eq!(inner(format).unwrap(), expected);
+    }
+
+    #[test]
     fn compiled_failed_parsing() {
         let err =
             ParsedFmt::new("Hello, {recipient}. Hope you are having a nice {time_descriptor.")


### PR DESCRIPTION
Because [`FormatError`](https://github.com/conradludgate/runtime-format/blob/5c0ac3835db774afb45842d5ca4e87383a2703d3/src/lib.rs#L142-L147) holds a reference to the problematic sections that caused the error, it's impossible to bubble these references up.

I've added two tests in this pr which show a common way errors are bubbled up in consumer's code. They fail to compile since `ParsedFmt::new` may return an error referencing either a local variable, or a reference which doesn't live past the end of the current function (due to the way that function bubbling works).

This should have been an issue, but since this repository is listed as a fork of another (even though there is no shared code as far as I can tell), Github doesn't allow for issues. It would be nice to have an issues board rather than submitting failing tests as PRs (since this is a compilation issue - the test can't even be run!).

Additionally, it would be nice to have a way to catch errors in the actual formatting process. Right now the only way to actually format a string is through the `Display` implementation, and the only way to get errors from this is by calling `fmt` manually with a formatter, catching the error, and then calling a separate function `status()` to bubble the real error up (and this is very unergonomic), or calling `to_string()`, which unavoidably panics immediately if there was a formatting error. According to [the documentation for this impl](https://doc.rust-lang.org/std/string/trait.ToString.html#impl-ToString-for-T), this is probably an improper `Display` impl? [According to Alex Crichton](https://internals.rust-lang.org/t/format-to-string-does-not-panic-on-std-fmt-error-intentional-or-not/2601/5), errors shouldn't be returned from the `Display` impl just because it can't be formatted, but this was a while ago, and things eem to have changed (namely `to_string()` does check for errors and panics, now). I think realistically, the API shouldn't be using `Display` because that implies some amount of infallibility in the formatting which can't be guaranteed. Instead, there should be a function which returns a `Result<String>` and a user should be required to unwrap this before they can display it (or do whatever else they want with it).